### PR TITLE
Don't create a directory instead of the lock file

### DIFF
--- a/src/singleinstance.rs
+++ b/src/singleinstance.rs
@@ -1,6 +1,6 @@
 //extern crate nix;
-extern crate file_lock;
 extern crate appdirs;
+extern crate file_lock;
 
 use file_lock::FileLock;
 use std::fs;
@@ -13,7 +13,6 @@ pub fn get_client_lock(clientname: &str) -> Result<FileLock, String> {
         Err(_) => return Err("Failed to fetch user_cache_dir".to_string()),
     };
     path.push("client_locks");
-    path.push(clientname);
 
     if let Err(err) = fs::create_dir_all(path.clone()) {
         match err.kind() {
@@ -22,8 +21,13 @@ pub fn get_client_lock(clientname: &str) -> Result<FileLock, String> {
         }
     }
 
+    path.push(clientname);
+
     match FileLock::lock(&path.to_str().unwrap(), false, true) {
         Ok(lockfile) => Ok(lockfile),
-        Err(err) => Err(format!("Failed to get lock for client '{}': {}", clientname, err)),
+        Err(err) => Err(format!(
+            "Failed to get lock for client '{}': {}",
+            clientname, err
+        )),
     }
 }


### PR DESCRIPTION
Really excited to see ActivityWatch working with sway! :smiley: 

Running the watcher on my system fails with a panic however, as the program tries to create the file lock at the path of a newly created directory.

By appending the client name to the path after creating the locks directory, this little bug is fixed.

My editor also formatted the file with `rustfmt` but I can undo the formatting if necessary.