### PR TITLE
README: Improve compatibility section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ Only supports wayland window managers that implements the following wayland prot
 - idle.xml (many)
 - wlr-foreign-toplevel-management-unstable-v1.xml (very few)
 
-Following window managers have implemented these protocols:
-- phosh (works)
-- sway (works on version 1.5 and up)
-- Wayfire (Not tested, but might work)
+| Window Manager | supported? | Details |
+|-----|-----|-----|
+| [phosh](https://gitlab.gnome.org/World/Phosh/phosh) | ✔️  | works |
+| [sway](https://swaywm.org/) | ✔️  | works on version 1.5 and up |
+| GNOME / [Mutter](https://gitlab.gnome.org/GNOME/mutter) | ❌ | no support for the protocols above |
+| [Wayfire](https://wayfire.org/) | | not tested, but might work |
+| KDE / [KWin](https://invent.kde.org/plasma/kwin) | |  |

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ If you want to autostart aw-watcher-window-wayland without aw-qt, you can use th
 ### Compatibility
 
 Only supports wayland window managers that implements the following wayland protocols:
-- idle.xml (many)
-- wlr-foreign-toplevel-management-unstable-v1.xml (very few)
+- [idle.xml](https://wayland.app/protocols/kde-idle) (many)
+- [wlr-foreign-toplevel-management-unstable-v1.xml](https://wayland.app/protocols/wlr-foreign-toplevel-management-unstable-v1) (very few)
 
 | Window Manager | supported? | Details |
 |-----|-----|-----|


### PR DESCRIPTION
Added details to the compatibility section. Special focus on making it clear that GNOME is not supported right now.

PS: I _assume_ KDE / Kwin is supported (via the idle.xml protocol), but I could not find a confirmation for it so for now there is just an empty row for KDE / Kwin.