### PR TITLE
Respect `$XDG_CACHE_HOME` in deskop file

### DIFF
--- a/aw-watcher-window-wayland.desktop
+++ b/aw-watcher-window-wayland.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=ActivityWatch Window Watcher
-Exec=bash -c 'logdir="${XDG_CACHE_HOME:-$HOME/.cache}/activitywatch/log/aw-watcher-window-wayland"; mkdir -p "$logdir"; RUST_BACKTRACE=1 aw-watcher-window-wayland > "$logdir/$(date -Iseconds).log" 2>&1'
+Exec=bash -c 'logdir="${XDG_CACHE_HOME:-$HOME/.cache}/activitywatch/log/aw-watcher-window-wayland" && mkdir -p "$logdir" && RUST_BACKTRACE=1 aw-watcher-window-wayland > "$logdir/$(date -Iseconds).log" 2>&1'
 Icon=
 Comment=
 X-GNOME-Autostart-enabled=true

--- a/aw-watcher-window-wayland.desktop
+++ b/aw-watcher-window-wayland.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=ActivityWatch Window Watcher
-Exec=bash -c 'logdir=~/.cache/activitywatch/log/aw-watcher-window-wayland; mkdir -p $logdir; RUST_BACKTRACE=1 aw-watcher-window-wayland > $logdir/$(date -Iseconds).log 2>&1'
+Exec=bash -c 'logdir="${XDG_CACHE_HOME:-$HOME/.cache}/activitywatch/log/aw-watcher-window-wayland"; mkdir -p "$logdir"; RUST_BACKTRACE=1 aw-watcher-window-wayland > "$logdir/$(date -Iseconds).log" 2>&1'
 Icon=
 Comment=
 X-GNOME-Autostart-enabled=true


### PR DESCRIPTION
If `$XDG_CACHE_HOME` is set, use that, otherwise default to `~/.cache`

Because the logdir can now contain whitespace, surround the rhs with double quotes, inside which shell variables are still expanded.

Further use  `&&` instead of `;` for early failure if one of the statements in the expression fails.