### PR TITLE
Kwin marked as not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ Only supports wayland window managers that implements the following wayland prot
 | [sway](https://swaywm.org/) | ✔️  | works on version 1.5 and up |
 | GNOME / [Mutter](https://gitlab.gnome.org/GNOME/mutter) | ❌ | no support for the protocols above |
 | [Wayfire](https://wayfire.org/) | | not tested, but might work |
-| KDE / [KWin](https://invent.kde.org/plasma/kwin) | |  |
+| KDE / [KWin](https://invent.kde.org/plasma/kwin) | ❌ |  |


### PR DESCRIPTION
Kwin, the KDE window manager and Wayland compositor, clearly does not work with this watcher when using it over Wayland. Further testing should be done to figure out more, I do not have the expertise required to figure out why, but it appears that Kwin does not support any of the protocols specified.  As mentioned by @renyuneyun in ActivityWatch/activitywatch#92 it is possible to get the active window from kwin, but a great deal more work would be required to make this happen. It may be a bit different than just adding another protocol though as this dose not **seem** to be just a protocol that would be required.