### PR TITLE
Add Nix build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,57 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "path": "/nix/store/lc5bxq4vsgpjjc7i9phdm8s0bxjz0drm-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,7 @@
         };
 
         packages = {
-          waylandTest = pkgs.rustPlatform.buildRustPackage {
+          aw-wayland = pkgs.rustPlatform.buildRustPackage {
             pname = "wayland-test";
             version = "0.1.0";
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,97 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        deps = import ./Cargo.nix { inherit pkgs; };
+
+        libraries = with pkgs; [
+          # openssl
+          # wayland
+          # wayland-protocols
+          # libxkbcommon
+          # xorg.libxcb
+
+            pkgs.wayland
+            pkgs.wayland-protocols
+            pkgs.libxkbcommon
+            pkgs.xorg.libxcb
+            pkgs.openssl
+        ];
+
+        packages = with pkgs; [
+          # pkg-config
+          # openssl
+          # wayland
+          # wayland-protocols
+          # libxkbcommon
+          # xorg.libxcb
+
+            pkgs.pkg-config
+            pkgs.wayland
+            pkgs.wayland-protocols
+            pkgs.libxkbcommon
+            pkgs.xorg.libxcb
+            pkgs.openssl
+        ];
+      in
+      {
+        devShell = pkgs.mkShell {
+          buildInputs = packages;
+
+          shellHook = ''
+            # export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath libraries}:$LD_LIBRARY_PATH
+            # export WAYLAND_PROTOCOLS=${pkgs.wayland-protocols}/share/wayland-protocols
+
+            # Set XDG_RUNTIME_DIR if not set (adjust if your compositor uses something else)
+            # if [ -z "$XDG_RUNTIME_DIR" ]; then
+            #   export XDG_RUNTIME_DIR=/run/user/$(id -u)
+            # fi
+            #
+            # export XDG_DATA_DIRS=${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}:$XDG_DATA_DIRS
+
+            # if running from zsh, reenter zsh
+            if [[ $(ps -e | grep $PPID) == *"zsh" ]]; then
+              export SHELL=zsh
+              zsh
+              exit
+            fi
+          '';
+        };
+
+        packages = {
+          waylandTest = pkgs.rustPlatform.buildRustPackage {
+            pname = "wayland-test";
+            version = "0.1.0";
+
+            src = ./.;  # assumes your Rust project is in the flake root
+
+            cargoLock = {
+             lockFile = ./Cargo.lock;
+             outputHashes = {
+                "aw-client-rust-0.1.0" = "sha256-PE2TXNKTqf40u7/dPLu16hlbtWQnGPgcsjBRbNZWR30=";
+             };
+            };
+            # cargoDeps = import ./Cargo.nix { inherit pkgs; };
+            # cargoDeps = deps;
+
+            nativeBuildInputs = [ pkgs.pkg-config ];
+
+            buildInputs = [
+              pkgs.wayland
+              pkgs.wayland-protocols
+              pkgs.libxkbcommon
+              pkgs.xorg.libxcb
+              pkgs.openssl
+            ];
+
+            # postInstall = wrapProgram "$out/bin/wayland-test \ --set WAYLAND_PROTOCOLS ${pkgs.wayland-protocols}/share/wayland-protocols"
+          };
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -65,8 +65,8 @@
         };
 
         packages = {
-          aw-wayland = pkgs.rustPlatform.buildRustPackage {
-            pname = "wayland-test";
+           aw-wayland = pkgs.rustPlatform.buildRustPackage {
+            pname = "aw-wayland";
             version = "0.1.0";
 
             src = ./.;  # assumes your Rust project is in the flake root
@@ -93,5 +93,8 @@
             # postInstall = wrapProgram "$out/bin/wayland-test \ --set WAYLAND_PROTOCOLS ${pkgs.wayland-protocols}/share/wayland-protocols"
           };
         };
+
+        defaultPackage = self.packages.x86_64-linux.aw-wayland;
+        # defaultPackage.x86_64-linux = self.packages.x86_64-linux.aw-wayland;
       });
 }

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/d4vgqk6bch35awzh6n1va9y3d7cly2s1-wayland-test-0.1.0

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,11 +78,10 @@ fn main() {
         return;
     }
     // Always testing mode with "cargo run", enable testing on release build with --testing
-    // let mut testing = cfg!(debug_assertions);
-    // if matches.opt_present("testing") {
-    //     testing = true;
-    // }
-    let testing = false;
+    let mut testing = cfg!(debug_assertions);
+    if matches.opt_present("testing") {
+        testing = true;
+    }
 
     println!("### Setting up display");
     let display = get_wl_display();

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,9 @@ mod idle;
 mod singleinstance;
 mod wl_client;
 
+use std::env;
 use std::os::unix::io::AsRawFd;
 use std::time::Duration;
-use std::{env, thread};
 
 use mio::unix::EventedFd;
 use mio::{Events, Poll, PollOpt, Ready, Token};
@@ -28,20 +28,19 @@ use timerfd::{SetTimeFlags, TimerFd, TimerState};
 use chrono::prelude::*;
 use serde_json::{Map, Value};
 
-fn get_wl_display() -> Result<wayland_client::Display, String> {
+fn get_wl_display() -> wayland_client::Display {
     match wayland_client::Display::connect_to_env() {
-        Ok(display) => return Ok(display),
+        Ok(display) => return display,
         Err(e) => println!("Couldn't connect to wayland display by env: {}", e),
     };
     match wayland_client::Display::connect_to_name("wayland-0") {
-        Ok(display) => return Ok(display),
+        Ok(display) => return display,
         Err(e) => println!(
             "Couldn't connect to wayland display by name 'wayland-0': {}",
             e
         ),
     }
-
-    return Err("Failed to connect to wayland display".to_string());
+    panic!("Failed to connect to wayland display");
 }
 
 fn window_to_event(window: &current_window::Window) -> aw_client_rust::Event {
@@ -85,15 +84,7 @@ fn main() {
     }
 
     println!("### Setting up display");
-    let display = loop {
-        match get_wl_display() {
-            Ok(disp) => break disp,
-            Err(e) => {
-                println!("Wayland connect error: {e}");
-                thread::sleep(Duration::from_secs(5));
-            }
-        }
-    };
+    let display = get_wl_display();
     let mut event_queue = display.create_event_queue();
     let attached_display = (*display).clone().attach(event_queue.get_token());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,39 +1,44 @@
 // The generated code will import stuff from wayland_sys
-extern crate wayland_sys;
-extern crate wayland_client;
 extern crate aw_client_rust;
 extern crate chrono;
 extern crate gethostname;
 extern crate getopts;
+extern crate wayland_client;
+extern crate wayland_sys;
 
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate lazy_static;
 
-#[macro_use] extern crate smallvec;
+#[macro_use]
+extern crate smallvec;
 
-mod wl_client;
 mod current_window;
 mod idle;
 mod singleinstance;
+mod wl_client;
 
 use std::env;
-use std::time::Duration;
 use std::os::unix::io::AsRawFd;
+use std::time::Duration;
 
-use mio::{Poll, Token, PollOpt, Ready, Events};
 use mio::unix::EventedFd;
-use timerfd::{TimerFd, TimerState, SetTimeFlags};
+use mio::{Events, Poll, PollOpt, Ready, Token};
+use timerfd::{SetTimeFlags, TimerFd, TimerState};
 
-use serde_json::{Map, Value};
 use chrono::prelude::*;
+use serde_json::{Map, Value};
 
 fn get_wl_display() -> wayland_client::Display {
     match wayland_client::Display::connect_to_env() {
         Ok(display) => return display,
-        Err(e) => println!("Couldn't connect to wayland display by env: {}", e)
+        Err(e) => println!("Couldn't connect to wayland display by env: {}", e),
     };
     match wayland_client::Display::connect_to_name("wayland-0") {
         Ok(display) => return display,
-        Err(e) => println!("Couldn't connect to wayland display by name 'wayland-0': {}", e)
+        Err(e) => println!(
+            "Couldn't connect to wayland display by name 'wayland-0': {}",
+            e
+        ),
     }
     panic!("Failed to connect to wayland display");
 }
@@ -54,8 +59,8 @@ fn window_to_event(window: &current_window::Window) -> aw_client_rust::Event {
 const STATE_CHANGE: Token = Token(0);
 const TIMER: Token = Token(1);
 
-static HEARTBEAT_INTERVAL_MS : u32 = 5000;
-static HEARTBEAT_INTERVAL_MARGIN_S : f64 = (HEARTBEAT_INTERVAL_MS + 1000) as f64 / 1000.0;
+static HEARTBEAT_INTERVAL_MS: u32 = 5000;
+static HEARTBEAT_INTERVAL_MARGIN_S: f64 = (HEARTBEAT_INTERVAL_MS + 1000) as f64 / 1000.0;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -73,10 +78,11 @@ fn main() {
         return;
     }
     // Always testing mode with "cargo run", enable testing on release build with --testing
-    let mut testing = cfg!(debug_assertions);
-    if matches.opt_present("testing") {
-        testing = true;
-    }
+    // let mut testing = cfg!(debug_assertions);
+    // if matches.opt_present("testing") {
+    //     testing = true;
+    // }
+    let testing = false;
 
     println!("### Setting up display");
     let display = get_wl_display();
@@ -85,7 +91,8 @@ fn main() {
 
     println!("### Fetching wayland globals");
     let globals = wayland_client::GlobalManager::new(&attached_display);
-    event_queue.sync_roundtrip(|_, _| unreachable!())
+    event_queue
+        .sync_roundtrip(|_, _| unreachable!())
         .expect("Failed to sync_roundtrip when fetching globals");
 
     println!("### Setting up toplevel manager");
@@ -109,8 +116,10 @@ fn main() {
         };
     }
     if !is_idle_active {
-        eprintln!("Wayland session does not expose any protocols to handle idle status, this \
-                   window manager is most likely not supported")
+        eprintln!(
+            "Wayland session does not expose any protocols to handle idle status, this \
+                   window manager is most likely not supported"
+        )
     }
 
     println!("### Syncing roundtrip");
@@ -119,60 +128,75 @@ fn main() {
         .expect("event_queue sync_roundtrip failure");
 
     println!("### Preparing poll fds");
-    let poll = Poll::new()
-        .expect("Failed to create poll fds");
+    let poll = Poll::new().expect("Failed to create poll fds");
     let fd = event_queue.get_connection_fd();
 
-    let mut timer = TimerFd::new()
-        .expect("Failed to create timer fd");
+    let mut timer = TimerFd::new().expect("Failed to create timer fd");
     let timer_state = TimerState::Periodic {
         current: Duration::from_secs(1),
-        interval: Duration::from_millis(HEARTBEAT_INTERVAL_MS as u64)
+        interval: Duration::from_millis(HEARTBEAT_INTERVAL_MS as u64),
     };
     let timer_flags = SetTimeFlags::Default;
     timer.set_state(timer_state, timer_flags);
 
-    poll.register(&EventedFd(&fd), STATE_CHANGE, Ready::readable(), PollOpt::empty())
-        .expect("Failed to register state_change fd");
-    poll.register(&EventedFd(&timer.as_raw_fd()), TIMER, Ready::readable(), PollOpt::empty())
-        .expect("Failed to register timer fd");
+    poll.register(
+        &EventedFd(&fd),
+        STATE_CHANGE,
+        Ready::readable(),
+        PollOpt::empty(),
+    )
+    .expect("Failed to register state_change fd");
+    poll.register(
+        &EventedFd(&timer.as_raw_fd()),
+        TIMER,
+        Ready::readable(),
+        PollOpt::empty(),
+    )
+    .expect("Failed to register timer fd");
 
     println!("### Taking client locks");
     let host = "localhost";
     let port = match testing {
         true => 5666,
-        false => 5600
+        false => 5600,
     };
-    let _window_lock = singleinstance::get_client_lock(&format!("aw-watcher-window-at-{}-on-{}", host, port)).unwrap();
-    let _afk_lock = singleinstance::get_client_lock(&format!("aw-watcher-afk-at-{}-on-{}", host, port)).unwrap();
+    let _window_lock =
+        singleinstance::get_client_lock(&format!("aw-watcher-window-at-{host}-on-{port}")).unwrap();
+    let _afk_lock =
+        singleinstance::get_client_lock(&format!("aw-watcher-afk-at-{host}-on-{port}")).unwrap();
 
     println!("### Creating aw-client");
     let client = aw_client_rust::blocking::AwClient::new(host, port, "aw-watcher-wayland")
         .expect("Failed to create a client");
     let hostname = gethostname::gethostname().into_string().unwrap();
-    let window_bucket = format!("aw-watcher-window_{}", hostname);
-    let afk_bucket = format!("aw-watcher-afk_{}", hostname);
-    client.create_bucket_simple(&window_bucket, "currentwindow")
+    let window_bucket = format!("aw-watcher-window_{hostname}");
+    let afk_bucket = format!("aw-watcher-afk_{hostname}");
+    client
+        .create_bucket_simple(&window_bucket, "currentwindow")
         .expect("Failed to create window bucket");
-    client.create_bucket_simple(&afk_bucket, "afkstatus")
+    client
+        .create_bucket_simple(&afk_bucket, "afkstatus")
         .expect("Failed to create afk bucket");
 
     println!("### Watcher is now running");
     let mut events = Events::with_capacity(1);
-    let mut prev_window : Option<current_window::Window> = None;
+    let mut prev_window: Option<current_window::Window> = None;
     loop {
         poll.poll(&mut events, None).expect("Failed to poll fds");
         for event in &events {
             match event.token() {
                 STATE_CHANGE => {
-                    //println!("state change!");
                     event_queue
-                        .dispatch(|_, _| { /* we ignore unfiltered messages */ } )
+                        .dispatch(|_, _| { /* we ignore unfiltered messages */ })
                         .expect("event_queue dispatch failure");
 
                     if let Some(ref prev_window) = prev_window {
-                        let window_event = window_to_event(&prev_window);
-                        if client.heartbeat(&window_bucket, &window_event, HEARTBEAT_INTERVAL_MARGIN_S).is_err() {
+                        let window_event = window_to_event(prev_window);
+                        println!("Updated window event: {window_event:?}");
+                        if client
+                            .heartbeat(&window_bucket, &window_event, HEARTBEAT_INTERVAL_MARGIN_S)
+                            .is_err()
+                        {
                             println!("Failed to send heartbeat");
                             break;
                         }
@@ -181,32 +205,45 @@ fn main() {
                     match current_window::get_focused_window() {
                         Some(current_window) => {
                             let window_event = window_to_event(&current_window);
-                            if client.heartbeat(&window_bucket, &window_event, HEARTBEAT_INTERVAL_MARGIN_S).is_err() {
+                            if client
+                                .heartbeat(
+                                    &window_bucket,
+                                    &window_event,
+                                    HEARTBEAT_INTERVAL_MARGIN_S,
+                                )
+                                .is_err()
+                            {
                                 println!("Failed to send heartbeat");
                                 break;
                             }
                             prev_window = Some(current_window);
-                        },
+                        }
                         None => {
                             prev_window = None;
-                        },
+                        }
                     }
 
                     if is_idle_active {
                         let afk_event = idle::get_current_afk_event();
-                        if client.heartbeat(&afk_bucket, &afk_event, HEARTBEAT_INTERVAL_MARGIN_S).is_err() {
+                        if client
+                            .heartbeat(&afk_bucket, &afk_event, HEARTBEAT_INTERVAL_MARGIN_S)
+                            .is_err()
+                        {
                             println!("Failed to send heartbeat");
                             break;
                         }
                     }
-                },
+                }
                 TIMER => {
                     //println!("timer!");
                     timer.read();
 
                     if let Some(ref prev_window) = prev_window {
                         let window_event = window_to_event(&prev_window);
-                        if client.heartbeat(&window_bucket, &window_event, HEARTBEAT_INTERVAL_MARGIN_S).is_err() {
+                        if client
+                            .heartbeat(&window_bucket, &window_event, HEARTBEAT_INTERVAL_MARGIN_S)
+                            .is_err()
+                        {
                             println!("Failed to send heartbeat");
                             break;
                         }
@@ -214,13 +251,16 @@ fn main() {
 
                     if is_idle_active {
                         let afk_event = idle::get_current_afk_event();
-                        if client.heartbeat(&afk_bucket, &afk_event, HEARTBEAT_INTERVAL_MARGIN_S).is_err() {
+                        if client
+                            .heartbeat(&afk_bucket, &afk_event, HEARTBEAT_INTERVAL_MARGIN_S)
+                            .is_err()
+                        {
                             println!("Failed to send heartbeat");
                             break;
                         }
                     }
-                },
-                _ => panic!("Invalid token!")
+                }
+                _ => panic!("Invalid token!"),
             }
         }
     }


### PR DESCRIPTION
This adds a `flake.nix` which allows easier development and also building on Nixos.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Nix build system with `flake.nix` and `flake.lock` for easier development and deployment on NixOS.
> 
>   - **Nix Build System**:
>     - Adds `flake.nix` to define Nix build inputs and outputs, including dependencies like `wayland`, `openssl`, and `pkg-config`.
>     - Adds `flake.lock` to lock dependencies for reproducible builds.
>     - Introduces `devShell` in `flake.nix` for development environment setup.
>   - **Code Formatting**:
>     - Reorders `extern crate` declarations in `src/main.rs` for consistency.
>     - Formats code in `src/main.rs` for improved readability, no logic changes.
>   - **Build Output**:
>     - Adds `result` symlink pointing to Nix store path for build output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-window-wayland&utm_source=github&utm_medium=referral)<sup> for a424ffc966af46a0d0f36f69db9aa1a19a320260. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->