### PR TITLE
chore: add systemd service file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose --release
     - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,41 @@
-.PHONY: all build package
+.PHONY: all build install clean
 
-PREFIX=/usr/local/bin
+# Determine PREFIX based on whether we're using sudo or not
+DESTDIR :=
+ifeq ($(SUDO_USER),)
+    PREFIX := $(HOME)/.local
+else
+    PREFIX := /usr/local
+endif
 
-CARGO_FLAGS=--release
+# Build in release mode by default, unless RELEASE=false
+ifeq ($(RELEASE), false)
+	CARGO_FLAGS :=
+	TARGET_DIR := debug
+else
+	CARGO_FLAGS := --release
+	TARGET_DIR := release
+endif
 
 all: build
 
 build:
 	cargo build $(CARGO_FLAGS)
 
-install:
-	install target/release/aw-watcher-window-wayland $(PREFIX)/aw-watcher-window-wayland
+install: build
+	# Install aw-watcher-window-wayland executable
+	mkdir -p $(DESTDIR)$(PREFIX)/bin/
+	install -m 755 target/$(TARGET_DIR)/aw-watcher-window-wayland $(DESTDIR)$(PREFIX)/bin/aw-watcher-window-wayland
+	# Install systemd user service
+ifeq ($(SUDO_USER),)
+	mkdir -p $(HOME)/.config/systemd/user
+	install -m 644 aw-watcher-window-wayland.service $(HOME)/.config/systemd/user/aw-watcher-window-wayland.service
+	systemctl --user daemon-reload || true
+else
+	mkdir -p $(DESTDIR)$(PREFIX)/lib/systemd/user
+	install -m 644 aw-watcher-window-wayland.service $(DESTDIR)$(PREFIX)/lib/systemd/user/aw-watcher-window-wayland.service
+	systemctl daemon-reload || true
+endif
+
+clean:
+	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,14 @@
-.PHONY: all build install clean
+.PHONY: all build install clean enable-service disable-service setup-wayland help
+
+help:
+	@echo "Available targets:"
+	@echo "  all             - Build the project (default)"
+	@echo "  build           - Build the project with cargo"
+	@echo "  install         - Install binary and systemd service"
+	@echo "  clean           - Remove build artifacts"
+	@echo "  enable-service  - Enable and start the systemd service"
+	@echo "  disable-service - Disable and stop the systemd service"
+	@echo "  setup-wayland   - Configure Wayland environment import"
 
 # Determine PREFIX based on whether we're using sudo or not
 DESTDIR :=
@@ -39,3 +49,70 @@ endif
 
 clean:
 	cargo clean
+
+enable-service:
+	@echo "Enabling and starting service..."
+ifeq ($(SUDO_USER),)
+	systemctl --user enable aw-watcher-window-wayland
+	systemctl --user start aw-watcher-window-wayland
+	@echo "Service status:"
+	@systemctl --user status aw-watcher-window-wayland --no-pager
+else
+	@echo "Note: For user service, run without sudo"
+	systemctl --user enable aw-watcher-window-wayland
+	systemctl --user start aw-watcher-window-wayland
+endif
+
+disable-service:
+	@echo "Disabling and stopping service..."
+	systemctl --user stop aw-watcher-window-wayland
+	systemctl --user disable aw-watcher-window-wayland
+	@echo "Service disabled."
+
+setup-wayland: enable-service
+	@echo "Configuring Wayland environment import..."
+	@echo ""
+	@echo "Detecting compositor configuration files..."
+	@if [ -f ~/.config/sway/config ]; then \
+		echo "Found Sway config at ~/.config/sway/config"; \
+		if grep -q "systemctl --user import-environment WAYLAND_DISPLAY" ~/.config/sway/config; then \
+			echo "✓ Environment import already configured"; \
+		else \
+			echo "" >> ~/.config/sway/config; \
+			echo "# Import WAYLAND_DISPLAY for systemd services" >> ~/.config/sway/config; \
+			echo "exec systemctl --user import-environment WAYLAND_DISPLAY" >> ~/.config/sway/config; \
+			echo "✓ Added environment import to Sway config"; \
+			echo "  Please reload Sway config or log out and back in"; \
+		fi; \
+	elif [ -f ~/.config/hypr/hyprland.conf ]; then \
+		echo "Found Hyprland config at ~/.config/hypr/hyprland.conf"; \
+		if grep -q "systemctl --user import-environment WAYLAND_DISPLAY" ~/.config/hypr/hyprland.conf; then \
+			echo "✓ Environment import already configured"; \
+		else \
+			echo "" >> ~/.config/hypr/hyprland.conf; \
+			echo "# Import WAYLAND_DISPLAY for systemd services" >> ~/.config/hypr/hyprland.conf; \
+			echo "exec-once = systemctl --user import-environment WAYLAND_DISPLAY" >> ~/.config/hypr/hyprland.conf; \
+			echo "✓ Added environment import to Hyprland config"; \
+			echo "  Please reload Hyprland config or log out and back in"; \
+		fi; \
+	else \
+		echo "Could not detect compositor config file."; \
+		echo ""; \
+		echo "Please manually add this line to your compositor startup:"; \
+		echo "  exec systemctl --user import-environment WAYLAND_DISPLAY"; \
+		echo ""; \
+		echo "Common locations:"; \
+		echo "  - Sway: ~/.config/sway/config"; \
+		echo "  - Hyprland: ~/.config/hypr/hyprland.conf"; \
+		echo "  - Others: check your compositor documentation"; \
+	fi
+	@echo ""
+	@echo "Restarting service to pick up environment changes..."
+	@systemctl --user restart aw-watcher-window-wayland 2>/dev/null || echo "Note: Service restart will happen after compositor reload"
+	@echo ""
+	@echo "⚠ IMPORTANT: The environment variable will only be available after:"
+	@echo "  1. Reloading your compositor config, OR"
+	@echo "  2. Logging out and back in"
+	@echo ""
+	@echo "After that, verify the service is working:"
+	@echo "  systemctl --user status aw-watcher-window-wayland"

--- a/aw-watcher-window-wayland.service
+++ b/aw-watcher-window-wayland.service
@@ -39,7 +39,7 @@ After=graphical-session.target
 [Service]
 Type=simple
 ExecStart=aw-watcher-window-wayland
-Restart=on-failure
+Restart=always
 RestartSec=10
 # Ensure aw-server is actually listening before starting (timeout after 60 seconds)
 ExecStartPre=/bin/sh -c 'i=0; until nc -z localhost 5600 || [ $i -eq 60 ]; do sleep 1; i=$((i+1)); done; nc -z localhost 5600'

--- a/aw-watcher-window-wayland.service
+++ b/aw-watcher-window-wayland.service
@@ -1,0 +1,46 @@
+########################################
+# aw-watcher-window-wayland.service   #
+########################################
+#
+# This service file provides an alternative way to run ActivityWatch watchers
+# without using aw-qt. The recommended approach is to use aw-qt, which manages
+# both the server and watchers automatically.
+#
+# Prerequisites:
+# - aw-server-rust must be installed and running
+# - This watcher must be built and installed
+# - Running a Wayland compositor that supports required protocols
+#
+# Installation:
+# 1. Build and install with: make install
+#    This installs both the binary and service file to ~/.local/
+# 2. Reload systemd: systemctl --user daemon-reload
+# 3. Enable the service: systemctl --user enable aw-watcher-window-wayland.service
+# 4. Start the service: systemctl --user start aw-watcher-window-wayland.service
+#
+# For system-wide installation (not recommended for user services):
+#    sudo make install
+#
+# The watcher will automatically start when aw-server is ready and listening on port 5600.
+#
+
+[Unit]
+Description=ActivityWatch Window Watcher for Wayland
+Documentation=https://github.com/ActivityWatch/aw-watcher-window-wayland
+After=aw-server.service
+Requires=aw-server.service
+# Wait for aw-server to be fully ready and listening on port 5600
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=aw-watcher-window-wayland
+Restart=on-failure
+RestartSec=10
+# Ensure aw-server is actually listening before starting
+ExecStartPre=/bin/sh -c 'until nc -z localhost 5600; do sleep 1; done'
+# Wayland watchers need access to Wayland display
+Environment="WAYLAND_DISPLAY=%E/wayland-0"
+
+[Install]
+WantedBy=default.target

--- a/aw-watcher-window-wayland.service
+++ b/aw-watcher-window-wayland.service
@@ -14,9 +14,11 @@
 # Installation:
 # 1. Build and install with: make install
 #    This installs both the binary and service file to ~/.local/
-# 2. Reload systemd: systemctl --user daemon-reload
-# 3. Enable the service: systemctl --user enable aw-watcher-window-wayland.service
-# 4. Start the service: systemctl --user start aw-watcher-window-wayland.service
+# 2. Import Wayland environment: systemctl --user import-environment WAYLAND_DISPLAY
+#    (Add this to your session startup script, e.g., ~/.config/sway/config or ~/.xinitrc)
+# 3. Reload systemd: systemctl --user daemon-reload
+# 4. Enable the service: systemctl --user enable aw-watcher-window-wayland.service
+# 5. Start the service: systemctl --user start aw-watcher-window-wayland.service
 #
 # For system-wide installation (not recommended for user services):
 #    sudo make install
@@ -31,6 +33,8 @@ After=aw-server.service
 Requires=aw-server.service
 # Wait for aw-server to be fully ready and listening on port 5600
 After=network.target
+# Ensure we run within a graphical session that has Wayland environment
+After=graphical-session.target
 
 [Service]
 Type=simple
@@ -39,8 +43,9 @@ Restart=on-failure
 RestartSec=10
 # Ensure aw-server is actually listening before starting (timeout after 60 seconds)
 ExecStartPre=/bin/sh -c 'i=0; until nc -z localhost 5600 || [ $i -eq 60 ]; do sleep 1; i=$((i+1)); done; nc -z localhost 5600'
-# Wayland watchers need access to Wayland display
-Environment="WAYLAND_DISPLAY=%t/wayland-0"
+# Note: WAYLAND_DISPLAY must be imported from your graphical session
+# Run: systemctl --user import-environment WAYLAND_DISPLAY
+# Add this command to your compositor/session startup script
 
 [Install]
 WantedBy=default.target

--- a/aw-watcher-window-wayland.service
+++ b/aw-watcher-window-wayland.service
@@ -37,10 +37,10 @@ Type=simple
 ExecStart=aw-watcher-window-wayland
 Restart=on-failure
 RestartSec=10
-# Ensure aw-server is actually listening before starting
-ExecStartPre=/bin/sh -c 'until nc -z localhost 5600; do sleep 1; done'
+# Ensure aw-server is actually listening before starting (timeout after 60 seconds)
+ExecStartPre=/bin/sh -c 'i=0; until nc -z localhost 5600 || [ $i -eq 60 ]; do sleep 1; i=$((i+1)); done; nc -z localhost 5600'
 # Wayland watchers need access to Wayland display
-Environment="WAYLAND_DISPLAY=%E/wayland-0"
+Environment="WAYLAND_DISPLAY=%t/wayland-0"
 
 [Install]
 WantedBy=default.target

--- a/aw-watcher-window-wayland.service
+++ b/aw-watcher-window-wayland.service
@@ -35,12 +35,16 @@ Requires=aw-server.service
 After=network.target
 # Ensure we run within a graphical session that has Wayland environment
 After=graphical-session.target
+# Allow up to 60 restart attempts within a 2-hour window before giving up
+StartLimitIntervalSec=7200
+StartLimitBurst=60
 
 [Service]
 Type=simple
 ExecStart=aw-watcher-window-wayland
 Restart=always
-RestartSec=10
+# Wait 2 minutes between restart attempts so aw-server has time to come back up
+RestartSec=120
 # Ensure aw-server is actually listening before starting (timeout after 60 seconds)
 ExecStartPre=/bin/sh -c 'i=0; until nc -z localhost 5600 || [ $i -eq 60 ]; do sleep 1; i=$((i+1)); done; nc -z localhost 5600'
 # Note: WAYLAND_DISPLAY must be imported from your graphical session


### PR DESCRIPTION
Add systemd user service file with proper dependencies on aw-server.
Includes port readiness check to ensure server is listening before
starting the watcher.

Note: This is an alternative to running aw-qt (recommended approach).

Disclaimer: QA and testing done utilizing real stupidity.  Except for that, everything is stiched together using artificial intelligence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds systemd service for `aw-watcher-window-wayland` and updates `Makefile` for conditional installation and build modes.
> 
>   - **Systemd Service**:
>     - Adds `aw-watcher-window-wayland.service` to run the watcher without `aw-qt`.
>     - Ensures `aw-server` is ready on port 5600 before starting the watcher.
>     - Configures service to restart on failure with a 10-second delay.
>   - **Makefile**:
>     - Adds conditional `PREFIX` based on `SUDO_USER` for user or system-wide installation.
>     - Adds `install` target to copy binary and service file to appropriate locations.
>     - Supports both release and debug build modes via `CARGO_FLAGS` and `TARGET_DIR`.
>   - **Misc**:
>     - `Makefile` includes `clean` target to run `cargo clean`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-window-wayland&utm_source=github&utm_medium=referral)<sup> for 548879379cbc6eab9e02296ea3032ea16d34fada. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->