### PR TITLE
Add COSMIC desktop support as fallback toplevel protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,15 @@ If you want to autostart aw-watcher-window-wayland without aw-qt, you can use th
 
 Only supports wayland window managers that implement the following wayland protocols:
 - [kde-idle.xml](https://wayland.app/protocols/kde-idle) (only KDE) OR [ext-idle-notify-v1.xml](https://wayland.app/protocols/ext-idle-notify-v1) (many)
-- [wlr-foreign-toplevel-management-unstable-v1.xml](https://wayland.app/protocols/wlr-foreign-toplevel-management-unstable-v1) (very few)
+- [wlr-foreign-toplevel-management-unstable-v1.xml](https://wayland.app/protocols/wlr-foreign-toplevel-management-unstable-v1) (very few) OR [zcosmic-toplevel-info-v1](https://github.com/pop-os/cosmic-protocols) (COSMIC)
+
+Window tracking uses wlr-foreign-toplevel-management when available, falling back to zcosmic_toplevel_info_v1 on COSMIC desktop.
 
 | Window Manager | supported? | Details |
 |-----|-----|-----|
 | [phosh](https://gitlab.gnome.org/World/Phosh/phosh) | ✔️  | works |
 | [sway](https://swaywm.org/) | ✔️  | works on version 1.5 and up |
+| [COSMIC](https://system76.com/cosmic/) | ✔️  | works via zcosmic_toplevel_info_v1 fallback |
 | GNOME / [Mutter](https://gitlab.gnome.org/GNOME/mutter) | ❌ | no support for the protocols above |
 | [Wayfire](https://wayfire.org/) | | not tested, but might work |
 | KDE / [KWin](https://invent.kde.org/plasma/kwin) | ❌ |  |

--- a/protocols/cosmic-toplevel-info-unstable-v1.xml
+++ b/protocols/cosmic-toplevel-info-unstable-v1.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="cosmic_toplevel_info_unstable_v1">
+  <copyright>
+    Copyright © 2018 Ilia Bozhinov
+    Copyright © 2020 Isaac Freund
+    Copyright © 2024 Victoria Brekenfeld
+    Permission to use, copy, modify, distribute, and sell this software
+    and its documentation for any purpose is hereby granted without fee.
+  </copyright>
+
+  <!-- Stub interfaces referenced by events but defined in other protocols -->
+  <interface name="zcosmic_workspace_handle_v1" version="1">
+    <description summary="stub for workspace handle"/>
+  </interface>
+
+  <interface name="ext_foreign_toplevel_handle_v1" version="1">
+    <description summary="stub for ext foreign toplevel handle"/>
+  </interface>
+
+  <interface name="ext_workspace_handle_v1" version="1">
+    <description summary="stub for ext workspace handle"/>
+  </interface>
+
+  <interface name="zcosmic_toplevel_info_v1" version="3">
+    <description summary="list toplevels and properties thereof">
+      The purpose of this protocol is to enable clients such as taskbars
+      or docks to access a list of opened applications and basic properties
+      thereof.
+    </description>
+
+    <event name="toplevel" deprecated-since="2">
+      <description summary="a toplevel has been created"/>
+      <arg name="toplevel" type="new_id" interface="zcosmic_toplevel_handle_v1"/>
+    </event>
+
+    <request name="stop" deprecated-since="2">
+      <description summary="stop sending events"/>
+    </request>
+
+    <event name="finished" deprecated-since="2">
+      <description summary="the compositor has finished with the toplevel manager"/>
+    </event>
+
+    <request name="get_cosmic_toplevel" since="2">
+      <description summary="get cosmic toplevel extension object"/>
+      <arg name="cosmic_toplevel" type="new_id" interface="zcosmic_toplevel_handle_v1"/>
+      <arg name="foreign_toplevel" type="object" interface="ext_foreign_toplevel_handle_v1"/>
+    </request>
+
+    <event name="done" since="2">
+      <description summary="all information about active toplevels have been sent"/>
+    </event>
+  </interface>
+
+  <interface name="zcosmic_toplevel_handle_v1" version="3">
+    <description summary="an open toplevel">
+      A zcosmic_toplevel_handle_v1 object represents an open toplevel window.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the zcosmic_toplevel_handle_v1 object"/>
+    </request>
+
+    <!-- Event opcodes must match compositor exactly -->
+    <event name="closed" deprecated-since="2">
+      <description summary="the toplevel has been closed"/>
+    </event>
+
+    <event name="done" deprecated-since="2">
+      <description summary="all information about the toplevel has been sent"/>
+    </event>
+
+    <event name="title" deprecated-since="2">
+      <description summary="title change"/>
+      <arg name="title" type="string"/>
+    </event>
+
+    <event name="app_id" deprecated-since="2">
+      <description summary="app_id change"/>
+      <arg name="app_id" type="string"/>
+    </event>
+
+    <event name="output_enter">
+      <description summary="toplevel entered an output"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <event name="output_leave">
+      <description summary="toplevel left an output"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <event name="workspace_enter" deprecated-since="3">
+      <description summary="toplevel entered a workspace"/>
+      <arg name="workspace" type="object" interface="zcosmic_workspace_handle_v1"/>
+    </event>
+
+    <event name="workspace_leave" deprecated-since="3">
+      <description summary="toplevel left a workspace"/>
+      <arg name="workspace" type="object" interface="zcosmic_workspace_handle_v1"/>
+    </event>
+
+    <enum name="state">
+      <description summary="types of states on the toplevel"/>
+      <entry name="maximized"  value="0" summary="the toplevel is maximized"/>
+      <entry name="minimized"  value="1" summary="the toplevel is minimized"/>
+      <entry name="activated"  value="2" summary="the toplevel is active"/>
+      <entry name="fullscreen" value="3" summary="the toplevel is fullscreen"/>
+      <entry name="sticky"     value="4" summary="the toplevel is sticky" since="2"/>
+    </enum>
+
+    <event name="state">
+      <description summary="the toplevel state changed"/>
+      <arg name="state" type="array"/>
+    </event>
+
+    <event name="geometry" since="2">
+      <description summary="the toplevel geometry changed"/>
+      <arg name="output" type="object" interface="wl_output"/>
+      <arg name="x" type="int"/>
+      <arg name="y" type="int"/>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </event>
+
+    <event name="ext_workspace_enter" since="3">
+      <description summary="toplevel entered a workspace"/>
+      <arg name="workspace" type="object" interface="ext_workspace_handle_v1"/>
+    </event>
+
+    <event name="ext_workspace_leave" since="3">
+      <description summary="toplevel left a workspace"/>
+      <arg name="workspace" type="object" interface="ext_workspace_handle_v1"/>
+    </event>
+  </interface>
+</protocol>

--- a/src/build.rs
+++ b/src/build.rs
@@ -13,6 +13,8 @@ fn main() {
          "./src/protocols/idle.rs"),
         ("./protocols/ext-idle-notify-v1.xml",
          "./src/protocols/ext-idle-notify-v1.rs"),
+        ("./protocols/cosmic-toplevel-info-unstable-v1.xml",
+         "./src/protocols/cosmic-toplevel-info.rs"),
     );
 
     // Create "./src/protocols" folder for generated bindings

--- a/src/current_window.rs
+++ b/src/current_window.rs
@@ -7,6 +7,9 @@ use super::wl_client as wl_client;
 use wl_client::toplevel_management::zwlr_foreign_toplevel_manager_v1::ZwlrForeignToplevelManagerV1 as ToplevelManager;
 use wl_client::toplevel_management::zwlr_foreign_toplevel_handle_v1::ZwlrForeignToplevelHandleV1 as ToplevelHandle;
 
+use wl_client::cosmic_toplevel::zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1 as CosmicToplevelManager;
+use wl_client::cosmic_toplevel::zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1 as CosmicToplevelHandle;
+
 #[derive(Clone)]
 pub struct Window {
     pub title: String,
@@ -82,13 +85,14 @@ fn assign_toplevel_handle(toplevel_handle: &wayland_client::Main<ToplevelHandle>
         });
 }
 
-pub fn assign_toplevel_manager(globals: &wayland_client::GlobalManager) -> () {
+pub fn assign_toplevel_manager(globals: &wayland_client::GlobalManager) -> Result<(), String> {
     use wl_client::toplevel_management::zwlr_foreign_toplevel_manager_v1::Event as ToplevelEvent;
 
     globals
         .instantiate_exact::<ToplevelManager>(1)
-        .expect("Wayland session does not expose a ToplevelManager object, \
-                 this window manager is most likely not supported")
+        .map_err(|_|
+            String::from("Wayland session does not expose a wlr ToplevelManager object")
+        )?
         .assign_mono(move |_toplevel_manager : Main<ToplevelManager>, event| {
             match event {
                 ToplevelEvent::Toplevel{ toplevel: handle } => {
@@ -108,4 +112,72 @@ pub fn assign_toplevel_manager(globals: &wayland_client::GlobalManager) -> () {
                 _ => panic!("Got an unexpected event!")
             }
         });
+    Ok(())
+}
+
+fn assign_cosmic_toplevel_handle(toplevel_handle: &wayland_client::Main<CosmicToplevelHandle>) -> () {
+    use wl_client::cosmic_toplevel::zcosmic_toplevel_handle_v1::Event as HandleEvent;
+
+    toplevel_handle
+        .assign_mono(|toplevel_handle : Main<CosmicToplevelHandle>, event| {
+            let mut window_state = WINDOW_STATE_LOCKED.lock()
+                .expect("Unable to take lock!");
+            let id = toplevel_handle.as_ref().id();
+            match event {
+                HandleEvent::AppId{ app_id } => {
+                    let window = window_state.all_windows.get_mut(&id)
+                        .expect("Tried to change appid on a non-existing window");
+                    window.appid = app_id.clone();
+                },
+                HandleEvent::Title{ title } => {
+                    let window = window_state.all_windows.get_mut(&id)
+                        .expect("Tried to change title on a non-existing window");
+                    window.title = title.clone();
+                },
+                HandleEvent::State{ state } => {
+                    for chunk in state.chunks_exact(4) {
+                        let val = u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+                        if val == 2 { // 2 == activated
+                            window_state.current_window = Some(id);
+                            break;
+                        }
+                    }
+                }
+                HandleEvent::Done => (),
+                HandleEvent::Closed => {
+                    let closed_window = window_state.all_windows.remove(&id)
+                        .expect("Tried to remove window which does not exist");
+                    println!("closed {}", closed_window.appid)
+                },
+                _ => () // Ignore output_enter, output_leave, workspace events
+            };
+        });
+}
+
+pub fn assign_cosmic_toplevel_manager(globals: &wayland_client::GlobalManager) -> Result<(), String> {
+    use wl_client::cosmic_toplevel::zcosmic_toplevel_info_v1::Event as CosmicToplevelEvent;
+
+    globals
+        .instantiate_exact::<CosmicToplevelManager>(1)
+        .map_err(|_|
+            String::from("Wayland session does not expose a zcosmic_toplevel_info_v1 object")
+        )?
+        .assign_mono(move |_toplevel_manager : Main<CosmicToplevelManager>, event| {
+            match event {
+                CosmicToplevelEvent::Toplevel{ toplevel: handle } => {
+                    let mut windows_state = WINDOW_STATE_LOCKED.lock()
+                        .expect("Unable to take lock!");
+                    let id = handle.as_ref().id();
+                    let window = Window {
+                        appid: "unknown".into(),
+                        title: "unknown".into(),
+                    };
+                    windows_state.all_windows.insert(id, window);
+                    assign_cosmic_toplevel_handle(&handle);
+                }
+                CosmicToplevelEvent::Finished => println!("COSMIC toplevel manager finished"),
+                _ => ()
+            }
+        });
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,20 @@ fn main() {
         .expect("Failed to sync_roundtrip when fetching globals");
 
     println!("### Setting up toplevel manager");
-    current_window::assign_toplevel_manager(&globals);
+    match current_window::assign_toplevel_manager(&globals) {
+        Ok(_) => println!("Using wlr-foreign-toplevel-management"),
+        Err(err_str) => {
+            eprintln!("{}", err_str);
+            match current_window::assign_cosmic_toplevel_manager(&globals) {
+                Ok(_) => println!("Using zcosmic_toplevel_info_v1"),
+                Err(err_str) => {
+                    eprintln!("{}", err_str);
+                    panic!("Wayland session does not expose any toplevel management protocol, \
+                            this window manager is most likely not supported");
+                }
+            }
+        }
+    }
 
     println!("### Setting up idle timeout");
     let mut is_idle_active = match idle::assign_ext_idle_notify(&globals, 120000) {

--- a/src/wl_client.rs
+++ b/src/wl_client.rs
@@ -45,3 +45,15 @@ pub mod ext_idle {
 
     include!("protocols/ext-idle-notify-v1.rs");
 }
+
+pub mod cosmic_toplevel {
+    pub(crate) use smallvec;
+    pub(crate) use wayland_sys as sys;
+    pub(crate) use wayland_client::{AnonymousObject, Interface, Main, Proxy, ProxyMap};
+    pub(crate) use wayland_client::protocol::{wl_surface, wl_region, wl_seat, wl_output};
+    pub(crate) use wayland_commons::{MessageGroup};
+    pub(crate) use wayland_commons::map::{Object, ObjectMetadata};
+    pub(crate) use wayland_commons::wire::{Argument, ArgumentType, Message, MessageDesc};
+
+    include!("protocols/cosmic-toplevel-info.rs");
+}


### PR DESCRIPTION
This adds support for [COSMIC desktop](https://system76.com/cosmic/) by using `zcosmic_toplevel_info_v1` as a fallback when `wlr-foreign-toplevel-management` is unavailable.

COSMIC already supports `ext-idle-notify-v1` for AFK detection, so with this change the watcher works fully on COSMIC — both window tracking and AFK status — without any additional watchers needed.

### How it works

The two toplevel protocols are structurally very similar (both emit title, app_id, state with activated=2, done, closed). On startup the watcher tries wlr-foreign-toplevel-management first; if the compositor doesn't expose it, it falls back to zcosmic_toplevel_info_v1. If neither is available, it exits with an error.

### Changes

- `protocols/cosmic-toplevel-info-unstable-v1.xml` — COSMIC toplevel protocol definition (with stub interfaces for workspace/foreign-toplevel references)
- `src/build.rs` — added entry for wayland-scanner code generation
- `src/wl_client.rs` — added `cosmic_toplevel` module (same pattern as existing modules)
- `src/current_window.rs` — refactored `assign_toplevel_manager()` to return `Result<(), String>` instead of panicking; added `assign_cosmic_toplevel_handle()` and `assign_cosmic_toplevel_manager()` with endian-safe state parsing via `chunks_exact(4)` + `u32::from_ne_bytes()`
- `src/main.rs` — replaced direct call with fallback chain: wlr → cosmic → panic
- `README.md` — added COSMIC to the compatibility table

### Testing

Tested on COSMIC desktop (NixOS). On startup the watcher logs:
```
### Setting up toplevel manager
Wayland session does not expose a wlr ToplevelManager object
Using zcosmic_toplevel_info_v1
### Watcher is now running
```

Window and AFK heartbeats confirmed flowing to aw-server-rust:
```
$ curl localhost:5600/api/0/buckets/aw-watcher-window_desktop/events?limit=1
[{"id":1238,"timestamp":"2026-03-07T03:28:21.057Z","duration":8.96,"data":{"app":"google-chrome","title":"ActivityWatch - Google Chrome"}}]
```

No changes to existing wlr or idle behavior — existing compositors (Sway, Hyprland, phosh) are unaffected.