### PR TITLE
fix: exit when the Wayland compositor connection hangs up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build package
+.PHONY: all build test package
 
 PREFIX=/usr/local/bin
 
@@ -8,6 +8,9 @@ all: build
 
 build:
 	cargo build $(CARGO_FLAGS)
+
+test:
+	./tests/compositor_crash_test.sh
 
 install:
 	install target/release/aw-watcher-window-wayland $(PREFIX)/aw-watcher-window-wayland

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use std::os::unix::io::AsRawFd;
 
 use mio::{Poll, Token, PollOpt, Ready, Events};
-use mio::unix::EventedFd;
+use mio::unix::{EventedFd, UnixReady};
 use timerfd::{TimerFd, TimerState, SetTimeFlags};
 
 use serde_json::{Map, Value};
@@ -166,6 +166,17 @@ fn main() {
             match event.token() {
                 STATE_CHANGE => {
                     //println!("state change!");
+                    // If the compositor died, the connection fd is hung up. Exit
+                    // so systemd can restart us against the new compositor.
+                    // Calling dispatch() on a dead connection must be avoided: it
+                    // busy-loops forever inside wayland-client 0.24, whose flush()
+                    // retry loop never breaks out on EPIPE.
+                    // Fixes: https://github.com/ActivityWatch/aw-watcher-window-wayland/issues/9
+                    let readiness = UnixReady::from(event.readiness());
+                    if readiness.is_hup() || readiness.is_error() {
+                        eprintln!("Lost connection to the Wayland compositor, exiting");
+                        std::process::exit(1);
+                    }
                     event_queue
                         .dispatch(|_, _| { /* we ignore unfiltered messages */ } )
                         .expect("event_queue dispatch failure");

--- a/tests/compositor_crash_test.sh
+++ b/tests/compositor_crash_test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Regression test: when the Wayland compositor dies, the watcher must exit so
+# that systemd (Restart=always) can restart it against the new compositor.
+#
+# Background: wayland-client 0.24 busy-loops on EPIPE inside dispatch() when
+# the compositor connection dies (the flush retry loop in rust_imp/queues.rs
+# never breaks on EPIPE). Without a hangup check the watcher then hangs
+# forever, burning CPU and recording nothing, while systemd still considers
+# the service healthy.
+#
+# Requires: sway (started headless), aw-server (rust), nc, cargo.
+
+set -u
+cd "$(dirname "$0")/.."
+
+tmpdir=$(mktemp -d)
+watcher_pid=
+sway_pid=
+server_pid=
+
+cleanup() {
+    [ -n "$watcher_pid" ] && kill "$watcher_pid" 2>/dev/null
+    [ -n "$sway_pid" ] && kill "$sway_pid" 2>/dev/null
+    [ -n "$server_pid" ] && kill "$server_pid" 2>/dev/null
+    wait 2>/dev/null
+    rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+command -v sway >/dev/null || { echo "SKIP: sway not installed"; exit 77; }
+command -v aw-server >/dev/null || { echo "SKIP: aw-server not installed"; exit 77; }
+command -v nc >/dev/null || { echo "SKIP: nc not installed"; exit 77; }
+
+# Use the release build: the debug build aborts at startup on modern rustc
+# (null-pointer check in the ancient nix 0.15 dependency that release mode
+# doesn't perform), and release is what actually ships anyway.
+echo "# Building watcher (release; run with --testing => port 5666)"
+cargo build --release --quiet 2>"$tmpdir/build.log" \
+    || { cat "$tmpdir/build.log" >&2; fail "cargo build failed"; }
+
+# The watcher in testing mode talks to port 5666; start an isolated aw-server
+# there unless one is already listening.
+if ! nc -z localhost 5666 2>/dev/null; then
+    aw-server --testing --port 5666 --dbpath "$tmpdir/aw-test.db" --no-legacy-import \
+        >"$tmpdir/aw-server.log" 2>&1 &
+    server_pid=$!
+fi
+for _ in $(seq 50); do nc -z localhost 5666 2>/dev/null && break; sleep 0.2; done
+nc -z localhost 5666 2>/dev/null || fail "aw-server did not start listening on port 5666"
+
+# Start a headless sway; it picks its own socket name, so have it report
+# WAYLAND_DISPLAY back to us via its config.
+cat > "$tmpdir/report-display.sh" <<EOF
+#!/bin/sh
+printf %s "\$WAYLAND_DISPLAY" > "$tmpdir/display"
+EOF
+chmod +x "$tmpdir/report-display.sh"
+echo "exec $tmpdir/report-display.sh" > "$tmpdir/sway.cfg"
+
+env -u WAYLAND_DISPLAY -u DISPLAY -u SWAYSOCK \
+    WLR_BACKENDS=headless WLR_LIBINPUT_NO_DEVICES=1 \
+    sway -c "$tmpdir/sway.cfg" >"$tmpdir/sway.log" 2>&1 &
+sway_pid=$!
+for _ in $(seq 50); do [ -s "$tmpdir/display" ] && break; sleep 0.2; done
+[ -s "$tmpdir/display" ] || { cat "$tmpdir/sway.log" >&2; fail "headless sway did not start"; }
+display=$(cat "$tmpdir/display")
+echo "# headless sway is up on $display (pid $sway_pid)"
+
+env WAYLAND_DISPLAY="$display" ./target/release/aw-watcher-window-wayland --testing \
+    >"$tmpdir/watcher.log" 2>&1 &
+watcher_pid=$!
+for _ in $(seq 50); do
+    grep -q "Watcher is now running" "$tmpdir/watcher.log" 2>/dev/null && break
+    sleep 0.2
+done
+grep -q "Watcher is now running" "$tmpdir/watcher.log" \
+    || { cat "$tmpdir/watcher.log" >&2; fail "watcher did not start"; }
+echo "# watcher is running (pid $watcher_pid)"
+
+echo "# killing sway to simulate a compositor crash"
+kill -9 "$sway_pid" 2>/dev/null
+wait "$sway_pid" 2>/dev/null
+sway_pid=
+
+# The watcher must exit within a few seconds so systemd can restart it.
+# (kill -0 succeeds on a zombie child, so check the process state instead.)
+for _ in $(seq 20); do
+    state=$(ps -o stat= -p "$watcher_pid" 2>/dev/null)
+    if [ -z "$state" ] || [ "${state:0:1}" = "Z" ]; then
+        wait "$watcher_pid" 2>/dev/null
+        rc=$?
+        watcher_pid=
+        echo "# watcher exited with code $rc"
+        echo "PASS: watcher exited after compositor death"
+        exit 0
+    fi
+    sleep 0.5
+done
+
+echo "--- watcher log ---" >&2
+cat "$tmpdir/watcher.log" >&2
+fail "watcher still running 10s after compositor death (would hang forever, recording nothing)"


### PR DESCRIPTION
This pull request was vibed up. It's an edge case (compositor typically goes down or is restarted only on reboots), but sharp enough that I found myself bleeding the other day.  I'm aware that the maintainer may have to spend much more time reviewing the changes than what I spent asking the AI to create this pull request. I'm OK with it to be rejected, even without any reason given.  The value I'm personally adding here is in testing, not in the code itself.

---

Fixes #9.

## Problem

When the compositor dies (crash, restart, logout), the watcher process survives but spins forever inside wayland-client 0.24's `EventQueue::dispatch()`, burning 100% CPU and recording nothing. #9 describes this with a stack trace; I hit the same thing when a sway restart left the watcher hung for 18 hours (8h25min CPU consumed) until it was manually restarted.

Root cause, in wayland-client 0.24.1 `rust_imp/queues.rs`: once the peer is gone, every `flush()` returns EPIPE, and the flush retry loop at the top of `dispatch()` treats EPIPE as non-fatal ("so we can continue reading to get the protocol error") but is missing the `break` — so it just calls `flush()` → EPIPE → `flush()` forever. The `.expect("event_queue dispatch failure")` in main.rs is never reached because `dispatch()` never returns. The 0.24 series is EOL so this won't be fixed on the library side; the eventual proper fix is the wayland-rs 0.31 migration (#32).

## Fix

Check the poll readiness for HUP/error before calling `dispatch()`, and exit(1) when the connection is dead. Under a service manager that restarts the watcher (e.g. a systemd unit with `Restart=always`, or aw-qt), it then comes back up against the new compositor socket within seconds instead of hanging until someone notices the data gap.

## Test

`tests/compositor_crash_test.sh` (also reachable as `make test`) starts a headless sway plus an aw-server in testing mode, runs the watcher against them, kills sway, and asserts the watcher exits within 10 seconds. It fails before this change (watcher still alive, spinning) and passes after. It requires sway and aw-server on the PATH and skips (exit 77) when they're missing.

Note: the test runs the release build with `--testing`, because debug builds currently abort at startup on recent rustc (a null-pointer check inside the old nix 0.15 dependency that only triggers with debug assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code), model Claude Fable 5
